### PR TITLE
Decode bytes, fixes #2

### DIFF
--- a/python/Article.py
+++ b/python/Article.py
@@ -48,7 +48,7 @@ class Article():
     def generate_questions_for(self, sec):
         # Rid of all parentheses for easier processing
         _sec = "".join(re.split('\(', 
-            sec.replace(")", "("))[0::2])
+            sec.decode("utf-8").replace(")", "("))[0::2])
 
         for sentence in sent_tokenize(_sec):
             qdata = self.get_question_data(sentence)


### PR DESCRIPTION
With Python3 the "sec" arg is bytes (not string). I just add a decode so the replace works. I think it will do no harm in Python2.