### PR TITLE
Prevent duplicate questions from being selected

### DIFF
--- a/python/Quiz.py
+++ b/python/Quiz.py
@@ -62,7 +62,9 @@ class Quiz():
 
 
 def _sample(population, number):
-    if len(population) <= number:
+    if not population:
+        return []
+    elif len(population) <= number:
         return [random.choice(population) for _ in range(number)]
     else:
         return random.sample(population, number)

--- a/python/Quiz.py
+++ b/python/Quiz.py
@@ -14,11 +14,10 @@ class Quiz():
 
     # used by the REST endpoint to give the browser 10 questions
     def get_ten_random(self):
-        selected = []
-        for i in range(0,11):
-            selected.append(random.choice(self.questions))
-
-        return selected
+        if len(self.questions) <= 10:
+            return self.questions
+        else:
+            return random.sample(self.questions, 10)
 
     # the follow 3 random-related functions
     # are used to give a pool of wrong answers

--- a/python/Quiz.py
+++ b/python/Quiz.py
@@ -14,10 +14,7 @@ class Quiz():
 
     # used by the REST endpoint to give the browser 10 questions
     def get_ten_random(self):
-        if len(self.questions) <= 10:
-            return self.questions
-        else:
-            return random.sample(self.questions, 10)
+        return _sample(self.questions, 10)
 
     # the follow 3 random-related functions
     # are used to give a pool of wrong answers
@@ -64,4 +61,8 @@ class Quiz():
             self.numbers.append(word)
 
 
-
+def _sample(population, number):
+    if len(population) <= number:
+        return population
+    else:
+        return random.sample(population, number)

--- a/python/Quiz.py
+++ b/python/Quiz.py
@@ -63,6 +63,6 @@ class Quiz():
 
 def _sample(population, number):
     if len(population) <= number:
-        return population
+        return [random.choice(population) for _ in range(number)]
     else:
         return random.sample(population, number)

--- a/python/Quiz.py
+++ b/python/Quiz.py
@@ -20,34 +20,13 @@ class Quiz():
     # are used to give a pool of wrong answers
     # to the browser
     def get_random_propers(self):
-        if len(self.propers) == 0:
-            return []
-
-        selected = []
-        for i in range(0,30):
-            selected.append(random.choice(self.propers))
-
-        return selected
+        return _sample(self.propers, 30)
 
     def get_random_locations(self):
-        if len(self.locations) == 0:
-            return []
-
-        selected = []
-        for i in range(0,30):
-            selected.append(random.choice(self.locations))
-
-        return selected
+        return _sample(self.locations, 30)
 
     def get_random_numbers(self):
-        if len(self.numbers) == 0:
-            return []
-
-        selected = []
-        for i in range(0,30):
-            selected.append(random.choice(self.numbers))
-
-        return selected
+        return _sample(self.numbers, 30)
 
     # when the parser/chunker matches a word/phrase
     # to our grammar, lets add it to the pool of potential


### PR DESCRIPTION
The `random.choice` method performs sampling with replacement. This means that the `get_ten_random` method could return the same question more than once which is not a great user experience.

Using `random.sample` (part of the standard library since 2.3 so we can for sure assume that it's available), we perform sampling without replacement so that we prevent any possibility of duplicate questions.