### PR TITLE
Make it less likely to show duplicate answers

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,9 +56,10 @@ function load_question() {
         
         answers = [];
         correct_answer = data['questions'][q_idx][2];
+        var wrong_answers = get_wrong_answers(label, correct_answer);
         answers.push(correct_answer);
-        answers.push(get_wrong_answer(label));
-        answers.push(get_wrong_answer(label));
+        answers.push(wrong_answers[0]);
+        answers.push(wrong_answers[1]);
         shuffle(answers);
 
         answer_a.innerHTML = answers[0];
@@ -67,6 +68,24 @@ function load_question() {
 
         q_idx += 1;
     }
+}
+
+function get_wrong_answers(label, correct_answer) {
+  var max_num_retries = 10;
+  var wrong_answer_1 = get_wrong_answer(label);
+  var wrong_answer_2 = get_wrong_answer(label);
+
+  for (var i = 0; i < max_num_retries; i++) {
+    var any_answers_same = wrong_answer_1 === wrong_answer_2 || wrong_answer_1 === correct_answer || wrong_answer_2 === correct_answer;
+    if (!any_answers_same) {
+      break;
+    }
+
+    wrong_answer_1 = get_wrong_answer(label);
+    wrong_answer_2 = get_wrong_answer(label);
+  }
+
+  return [wrong_answer_1, wrong_answer_2];
 }
 
 function get_wrong_answer(label) {


### PR DESCRIPTION
Previously, we generated two incorrect answers for every question by sampling with replacement from the pool of all possible entities for some question. This means that we can display duplicate answers for a question in two scenarios: (1) we sample the same incorrect answer twice, or (2) one of the sampled incorrect answers is the same as the correct answer.

This commit adds some retry logic to the front-end that re-samples the incorrect answers if any of the two conditions above occurred. This does not eliminate the possibility of duplicate answers being displayed (e.g. consider the situation where we only have two candidate answers), but it should greatly reduce the impact to the user.

Fixes #5