### PR TITLE
Improve logic to redact question texts

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,14 +48,14 @@ function load_question() {
         make_request(curQuery, new_article_query);
     } else {
         label =  data['questions'][q_idx][0];
+        correct_answer = data['questions'][q_idx][2];
 
         question_body.innerHTML = convert_to_redacted(
-            data['questions'][q_idx][1], 
-            data['questions'][q_idx][2],
+            data['questions'][q_idx][1],
+            correct_answer,
             label);
         
         answers = [];
-        correct_answer = data['questions'][q_idx][2];
         answers.push(correct_answer);
         answers.push(get_wrong_answer(label));
         answers.push(get_wrong_answer(label));

--- a/script.js
+++ b/script.js
@@ -101,7 +101,7 @@ function convert_to_redacted(text, answer, label) {
     if (label === "NUMBER") {
         // if the answer is a number, we want to match
         // the numerical portion, not $, %, etc
-        _answer = answer.replace(/[^0-9]/g,'');
+        _answer = answer.replace(/[^0-9.,]/g,'');
 
         // if the the number is spelled out
         // ie. `twelve`, leave it as it is.

--- a/script.js
+++ b/script.js
@@ -50,10 +50,13 @@ function load_question() {
         label =  data['questions'][q_idx][0];
         correct_answer = data['questions'][q_idx][2];
 
-        question_body.innerHTML = convert_to_redacted(
+        var redacted = convert_to_redacted(
             data['questions'][q_idx][1],
             correct_answer,
             label);
+
+        question_body.innerHTML = redacted.text;
+        correct_answer = redacted.answer;
         
         answers = [];
         answers.push(correct_answer);
@@ -106,7 +109,14 @@ function convert_to_redacted(text, answer, label) {
             _answer = answer;
         }
     }
-    return text.replace(_answer, "❓");
+
+    var redacted_text = text.replace(_answer, "❓");
+    var redacted_answer = _answer;
+
+    return {
+      text: redacted_text,
+      answer: redacted_answer,
+    };
 }
 
 function handleAnswerResponse(answer_given) {


### PR DESCRIPTION
To give enough context for the answer, the redaction algorithm does not redact context words. However, this sometimes leads to nothing at all being redacted, e.g. for the question "an Earth year is about 365.26 years long", the correct answer "365.26" will be shortened to "36526" and then we'll fail to redact that token in the question text.

This problem was, for example, reported in #9. After applying this patch, the situation described in that issues is fixed:

![image](https://cloud.githubusercontent.com/assets/1086421/24327204/c543f1a4-117f-11e7-8303-9c2b5c0fa289.png)

This patch also fixes another failure mode related to context words: we may have a question like "the atmosphere is made up of ?% CO2" and one of the answers is "52%". That's too easy! After this change, the correct answer in this example would be redacted to "52" making the question less easy to answer.